### PR TITLE
FAVE-42006: Add Create Preorder QR Endpoint

### DIFF
--- a/alipay.gemspec
+++ b/alipay.gemspec
@@ -22,5 +22,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "minitest"
+  spec.add_development_dependency "minitest-mock" if RUBY_VERSION >= '3.2'
   spec.add_development_dependency "webmock"
 end

--- a/doc/legacy_api.md
+++ b/doc/legacy_api.md
@@ -540,7 +540,71 @@ notify_params = params.except(*request.path_parameters.keys)
 Alipay::Notify.verify?(notify_params, options = {})
 ```
 
-### QR Code 生成二维码
+### QR Code 生成支付二维码
+
+#### Name
+
+```ruby
+alipay.acquire.precreate
+```
+
+#### Definition
+
+```ruby
+Alipay::Service.create_preorder_qr_code({PARAMS}, {OPTIONS})
+```
+
+#### Example
+
+```ruby
+create_qr_code_params = {
+  out_trade_no: 'out_trade_no_20190904_163941',
+  subject: "Mika's coffee shop",
+  product_code: 'OVERSEAS_MBARCODE_PAY',
+  currency: 'USD',
+  trans_currency: 'USD',
+  total_fee: '0.01',
+  extend_params: {
+    secondary_merchant_id: '1314520',
+    secondary_merchant_name: "Mika's coffee shop",
+    secondary_merchant_industry: '5499',
+    store_name: "Mika's coffee shop",
+    store_id: '1993'
+  }
+}
+
+Alipay::Service.create_preorder_qr_code(create_qr_code_params)
+# => 'https://api-sea-global.alipayplus.com/gateway.do?service=alipay.acquire.precreate...'
+```
+
+#### ARGUMENTS
+
+| Key | Requirement | Description |
+| --- | ----------- | ----------- |
+| out_trade_no | required | Unique order number in merchant's system. |
+| subject | required | Title or subject of the order. |
+| product_code | required | Product code assigned by Alipay; for QR code payment use "OVERSEAS_MBARCODE_PAY". |
+| currency | required | Settlement currency, e.g., "USD". |
+| trans_currency | optional | Transaction currency, e.g., "USD". Required if settlement currency differs from transaction currency. |
+| total_fee | required | Total order amount, e.g., "0.01". |
+| extend_params | required | Additional business parameters in JSON format. Contains secondary merchant and store details for international merchants. |
+| timestamp | optional | Order creation time. If not set, defaults to current time. Format: "yyyy-MM-dd HH:mm:ss" (24-hour) UTC. |
+
+#### EXTEND_PARAMS ARGUMENTS (required)
+
+| Key | Requirement | Description |
+| --- | ----------- | ----------- |
+| secondary_merchant_id | required | Sub-merchant identifier. |
+| secondary_merchant_name | required | Sub-merchant's name. |
+| secondary_merchant_industry | required | MCC (Merchant Category Code) of sub-merchant, e.g., "5499". |
+| store_name | required | Store name of sub-merchant. |
+| store_id | required | Store ID of sub-merchant. |
+
+This is not a complete list of arguments, please read official document:
+https://global.alipay.com/docs/ac/global/precreate_transaction
+
+
+### Merchant QR Code 生成商户二维码
 
 #### Name
 
@@ -600,7 +664,7 @@ Alipay::Service.create_merchant_qr_code(create_qr_code_params)
 
 This is not a complete list of arguments, please read official document: https://global.alipay.com/docs/ac/global/qrcode_create#biz_data
 
-### QR Code 修改二维码
+### QR Code 修改商户二维码
 
 #### Name
 

--- a/lib/alipay/service.rb
+++ b/lib/alipay/service.rb
@@ -207,6 +207,36 @@ module Alipay
       request_uri(params, options).to_s
     end
 
+    CREATE_PREORDER_QR_CODE_REQUIRED_PARAMS = %w( out_trade_no subject product_code total_fee currency trans_currency extend_params )
+    CREATE_PREORDER_QR_CODE_REQUIRED_EXTEND_PARAMS = %w( secondary_merchant_id secondary_merchant_name secondary_merchant_industry store_name store_id )
+    def self.create_preorder_qr_code(params, options = {})
+      params = Utils.stringify_keys(params)
+      check_required_params(params, CREATE_PREORDER_QR_CODE_REQUIRED_PARAMS)
+      extend_params = nil
+
+      if params['extend_params']
+        params['extend_params'] = Utils.stringify_keys(params['extend_params'])
+        check_required_params(params['extend_params'], CREATE_PREORDER_QR_CODE_REQUIRED_EXTEND_PARAMS)
+
+        data = params.delete('extend_params')
+        extend_params = data.map do |key, value|
+          "\"#{key}\": \"#{value}\""
+        end.join(',')
+      end
+
+      extend_params = "{#{extend_params}}"
+
+      params = {
+        'service'        => 'alipay.acquire.precreate',
+        '_input_charset' => 'utf-8',
+        'partner'        => options[:pid] || Alipay.pid,
+        'timestamp'      => Time.now.utc.strftime('%Y-%m-%d %H:%M:%S').to_s,
+        'extend_params'  => extend_params
+      }.merge(params)
+
+      request_uri(params, options).to_s
+    end
+
     CREATE_MERCHANT_QR_CODE_REQUIRED_PARAMS = %w( biz_type biz_data )
     CREATE_MERCHANT_QR_CODE_REQUIRED_BIZ_DATA_PARAMS = %w( secondary_merchant_industry secondary_merchant_id secondary_merchant_name trans_currency currency )
     def self.create_merchant_qr_code(params, options = {})

--- a/test/alipay/service_test.rb
+++ b/test/alipay/service_test.rb
@@ -263,6 +263,31 @@ class Alipay::ServiceTest < Minitest::Test
     assert_equal "#{Alipay.legacy_gateway_url}/gateway.do?service=batch_trans_notify&_input_charset=utf-8&partner=1000000000000000&pay_date=20080107&notify_url=https%3A%2F%2Fexample.com%2Forders%2F20150401000-0001%2Fnotify&account_name=%E6%AF%9B%E6%AF%9B&detail_data=0315006%5Etestture0002%40126.com%5E%E5%B8%B8%E7%82%9C%E4%B9%B0%E5%AE%B6%5E1000.00%5Ehello&batch_no=20080107001&batch_num=1&batch_fee=1000.0&email=biz_932%40alitest.com&sign_type=MD5&sign=59c611607daafd1337e96b22404bd521", Alipay::Service.batch_trans_notify_url(options)
   end
 
+  def test_create_preorder_qr_code
+    subject = "Mika's coffee shop"
+    params = {
+      out_trade_no: 'out_trade_no_20190904_163941',
+      subject: subject,
+      product_code: 'OVERSEAS_MBARCODE_PAY',
+      currency: 'USD',
+      trans_currency: 'USD',
+      total_fee: '0.01',
+      seller_id: '2088021966388155',
+      extend_params: {
+        secondary_merchant_id: '1314520',
+        secondary_merchant_name: subject,
+        secondary_merchant_industry: '5499',
+        store_name: subject,
+        store_id: '1993'
+      }
+    }
+
+    current_time = Time.utc(2023, 12, 12, 1, 1, 1)
+    Time.stub :now, current_time do
+      assert_equal "#{Alipay.legacy_gateway_url}/gateway.do?service=alipay.acquire.precreate&_input_charset=utf-8&partner=1000000000000000&timestamp=2023-12-12+01%3A01%3A01&extend_params=%7B%22secondary_merchant_id%22%3A+%221314520%22%2C%22secondary_merchant_name%22%3A+%22Mika%27s+coffee+shop%22%2C%22secondary_merchant_industry%22%3A+%225499%22%2C%22store_name%22%3A+%22Mika%27s+coffee+shop%22%2C%22store_id%22%3A+%221993%22%7D&out_trade_no=out_trade_no_20190904_163941&subject=Mika%27s+coffee+shop&product_code=OVERSEAS_MBARCODE_PAY&currency=USD&trans_currency=USD&total_fee=0.01&seller_id=2088021966388155&sign_type=MD5&sign=3d459c194700ce414e4865ea64ef0fbd", Alipay::Service.create_preorder_qr_code(params)
+    end
+  end
+
   def test_create_merchant_qr_code
     params = {
       biz_type: "OVERSEASHOPQRCODE",

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,5 @@
 require 'minitest/autorun'
+require 'minitest/mock'
 require 'alipay'
 require 'webmock/minitest'
 


### PR DESCRIPTION
Integrate Create Preorder QR Code in legacy API.
Note: I also opened a PR in origin repo. If that PR is merged, we can obsolete this forked gem and just use the original gem in future.